### PR TITLE
chore (docs): update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Optional. `${{ github.token }}` is used by default.
 Optional. Pass hadolint flags:
 ```
 with:
-  hadolint_flags: --thrusted-repository docker.io
+  hadolint_flags: --trusted-registry docker.io
 ```
 
 ### `hadolint_ignore`


### PR DESCRIPTION
Update the README to fix a minor issue with the `hadolint_flags:`
When I ran the action with the documented flag, it failed referencing an error "Invalid option `--trusted-repository'
This fixes Issue #76